### PR TITLE
Fix off-by-one indexing in derive-cells

### DIFF
--- a/src/clj_tiny_grid/core.clj
+++ b/src/clj_tiny_grid/core.clj
@@ -1,5 +1,5 @@
 (ns clj-tiny-grid.core
-  (:use [clj-tuple]))
+  (:require [clj-tuple :refer [tuple]]))
 
 (defmacro indmap
   "map a pair of co-ordinates to an index"
@@ -9,7 +9,7 @@
 (defn derive-cells
   [xs width height]
   (map (fn [i x] (tuple (mod i width)
-                       (int (/ i height)) x))
+                       (int (/ i width)) x))
        (range (* width height)) xs))
 
 (defrecord Grid [vec width height]


### PR DESCRIPTION
+ The function derive-cells was generating indices outside the bounds of the original grid in the case where `width' =/= `height'
   which was results in map-cells and map-cell-vals creating malformed grids. e.g:
    (derive-cells [1 2 3 4 5 6] 3 2) => [(0 0 1) (1 0 2) (2 1 3) (0 1 4) (1 2 5) (2 2 6)]
  instead of
    (derive-cells [1 2 3 4 5 6] 3 2) => [(0 0 1) (1 0 2) (2 0 3) (0 1 4) (1 1 5) (2 1 6)]

+ Fixed warnings due to clj-tuple shadowing `vector' and `hash-map' which are not used by this namespace
   so reduced the refer list to just `tuple'.